### PR TITLE
dev-limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Jenkins will now copy files into /connector directory in S3 buckets
 - code.json version number is now automatically updated
 - changed schema so a table is returned for each parameter code
+- removed limit of ten results for search display(We are no longer using anything of sufficient size to be a problem) 

--- a/src/components/CustomAutoComplete.vue
+++ b/src/components/CustomAutoComplete.vue
@@ -72,7 +72,7 @@ export default {
       this.setEventListener();
 
       if (!this.display || this.display === null) {
-        this.results = this.source; //.slice(0, 10);
+        this.results = this.source;
         this.$emit("results", { results: this.results });
         this.loading = false;
         return true;

--- a/src/components/CustomAutoComplete.vue
+++ b/src/components/CustomAutoComplete.vue
@@ -72,7 +72,7 @@ export default {
       this.setEventListener();
 
       if (!this.display || this.display === null) {
-        this.results = this.source.slice(0, 10);
+        this.results = this.source; //.slice(0, 10);
         this.$emit("results", { results: this.results });
         this.loading = false;
         return true;


### PR DESCRIPTION
Removed the limit of 10 results in the autocomplete search boxes. We are no longer using anything large enough to require this restriction to ensure smooth operation within Tableau Desktop's browser.