### PR TITLE
Increase allowed user input of Site ID's to 15 digits

### DIFF
--- a/src/inputValidation.js
+++ b/src/inputValidation.js
@@ -103,7 +103,7 @@ const validateSiteInputs = (sites, instance) => {
   let regex = /^(((\d){8}(\d?){7}),)*((\d){8}(\d?){7})$/;
 
   if (!sites.replace(/\s/g, "").match(regex)) {
-    return "site list in invalid format"; // 1 or more 8-12 digit site codes
+    return "site list in invalid format"; // 1 or more 8-15 digit site codes
   }
   return true;
 };

--- a/src/inputValidation.js
+++ b/src/inputValidation.js
@@ -100,7 +100,7 @@ const roundCoordinateInputs = coordinates => {
 const validateSiteInputs = (sites, instance) => {
   if (instance.$store.getters.locationMode != locationMode.SITE) return true;
 
-  let regex = /^(((\d){8}(\d?){4}),)*((\d){8}(\d?){4})$/;
+  let regex = /^(((\d){8}(\d?){7}),)*((\d){8}(\d?){7})$/;
 
   if (!sites.replace(/\s/g, "").match(regex)) {
     return "site list in invalid format"; // 1 or more 8-12 digit site codes


### PR DESCRIPTION
Found that Web Data Connector was only allowing Site ID's of 8-12 digits, as documented in Issue 187 but description of data connector in interface instructs users to enter Site ID's of 8-15 digits. Pull request would change code to allow up to 15 digits, but if there was a reason to limit length to 12 let me know. 